### PR TITLE
Fix new table for keyspace uses default session

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -89,7 +89,7 @@ func (ks Keyspace) NewTable(name string, rowKeys, rangeKeys []string, row interf
 		row:       row,
 
 		keyspace: ks,
-		session:  defaultSession,
+		session:  ks.session,
 	}
 }
 

--- a/keyspace.go
+++ b/keyspace.go
@@ -103,3 +103,7 @@ func (ks Keyspace) Session() *gocql.Session {
 	}
 	return ks.session
 }
+
+func (ks *Keyspace) SetSession(session *gocql.Session) {
+	ks.session = session
+}


### PR DESCRIPTION
This PR fixes using the default session directly when creating a new table via `keyspace.NewTable` as well as the inability to set the session to use when operating on a Keyspace object.
