### PR TITLE
Fix potential data race in query iterator

### DIFF
--- a/query.go
+++ b/query.go
@@ -68,15 +68,11 @@ func (i *Iterator) Range() <-chan interface{} {
 			next := i.Next()
 			if next == nil { // We clean up when we're done
 				close(rangeChan)
-				close(i.done)
-				i.done = nil
 				return
 			}
 			select {
 			case <-i.done: // We clean up when we're done
 				close(rangeChan)
-				close(i.done)
-				i.done = nil
 				return
 			case rangeChan <- next:
 			}
@@ -87,7 +83,7 @@ func (i *Iterator) Range() <-chan interface{} {
 
 func (i *Iterator) Close() error {
 	if done := i.done; done != nil {
-		done <- true
+		close(i.done)
 	}
 	return i.iter.Close()
 }

--- a/query.go
+++ b/query.go
@@ -62,7 +62,8 @@ func (i *Iterator) Next() interface{} {
 
 func (i *Iterator) Range() <-chan interface{} {
 	rangeChan := make(chan interface{})
-	i.done = make(chan bool)
+	done := make(chan bool)
+	i.done = done
 	go func() {
 		for {
 			next := i.Next()
@@ -71,7 +72,7 @@ func (i *Iterator) Range() <-chan interface{} {
 				return
 			}
 			select {
-			case <-i.done: // We clean up when we're done
+			case <-done: // We clean up when we're done
 				close(rangeChan)
 				return
 			case rangeChan <- next:
@@ -84,6 +85,7 @@ func (i *Iterator) Range() <-chan interface{} {
 func (i *Iterator) Close() error {
 	if done := i.done; done != nil {
 		close(i.done)
+		i.done = nil
 	}
 	return i.iter.Close()
 }


### PR DESCRIPTION
`i.done` was read from and written to by multiple goroutines which points to a potential data race. Using the fact that closing a channel fires the case statement in worker routines listening for that is the safe alternative.
