### PR TITLE
Add set in table creation

### DIFF
--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -13,6 +13,7 @@ import (
 	r "github.com/kristoiv/gocqltable/reflect"
 )
 
+// RangeInterface abstracts a query builder.
 type RangeInterface interface {
 	LessThan(rangeKey string, value interface{}) RangeInterface
 	LessThanOrEqual(rangeKey string, value interface{}) RangeInterface
@@ -26,14 +27,19 @@ type RangeInterface interface {
 	Fetch() (interface{}, error)
 }
 
+// CRUD forms the basis for table peer classes implementing the logic for row-based operations.
+// You may embed this struct into your own and selectively override certain functions,
+// thereby centralizing common behaviors and/or abstractions (think soft delete, timestamps etc.).
 type CRUD struct {
 	gocqltable.TableInterface
 }
 
+// Insert upserts an entity into a table.
 func (t CRUD) Insert(row interface{}) error {
 	return t.insert(row, nil)
 }
 
+// InsertWithTTL upserts an entity into a table using a TTL.
 func (t CRUD) InsertWithTTL(row interface{}, ttl *time.Time) error {
 	return t.insert(row, ttl)
 }

--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -20,6 +20,7 @@ type RangeInterface interface {
 	MoreThan(rangeKey string, value interface{}) RangeInterface
 	MoreThanOrEqual(rangeKey string, value interface{}) RangeInterface
 	EqualTo(rangeKey string, value interface{}) RangeInterface
+	Contains(rangeKey string, value interface{}, queryKey bool) RangeInterface
 	OrderBy(fieldAndDirection string) RangeInterface
 	Limit(l int) RangeInterface
 	Select(s []string) RangeInterface
@@ -270,6 +271,18 @@ func (r Range) MoreThanOrEqual(rangeKey string, value interface{}) RangeInterfac
 
 func (r Range) EqualTo(rangeKey string, value interface{}) RangeInterface {
 	r.where = append(r.where, fmt.Sprintf("%q", strings.ToLower(rangeKey))+" = ?")
+	r.whereVals = append(r.whereVals, value)
+	return r
+}
+
+// Contains can be used to query indexed map/set/list columns.
+// Pass true as the last argument in order to query for a key-indexed map.
+func (r Range) Contains(rangeKey string, value interface{}, queryKey bool) RangeInterface {
+	if queryKey {
+		r.where = append(r.where, fmt.Sprintf("%q", strings.ToLower(rangeKey))+" CONTAINS KEY ?")
+	} else {
+		r.where = append(r.where, fmt.Sprintf("%q", strings.ToLower(rangeKey))+" CONTAINS ?")
+	}
 	r.whereVals = append(r.whereVals, value)
 	return r
 }

--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -1,12 +1,11 @@
 package recipes
 
 import (
-	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"strings"
-	"reflect"
 	"time"
 
 	"github.com/kristoiv/gocqltable"
@@ -40,7 +39,6 @@ func (t CRUD) InsertWithTTL(row interface{}, ttl *time.Time) error {
 }
 
 func (t CRUD) insert(row interface{}, ttl *time.Time) error {
-
 	rowKeys := t.RowKeys()
 	rangeKeys := t.RangeKeys()
 
@@ -63,7 +61,7 @@ func (t CRUD) insert(row interface{}, ttl *time.Time) error {
 		for _, rowKey := range append(rowKeys, rangeKeys...) {
 			if strings.ToLower(key) == strings.ToLower(rowKey) {
 				if value == nil {
-					return errors.New(fmt.Sprintf("Inserting row failed due to missing key value (for key %q)", rowKey))
+					return fmt.Errorf("Inserting row failed due to missing key value (for key %q)", rowKey)
 				}
 				break
 			}
@@ -89,16 +87,14 @@ func (t CRUD) insert(row interface{}, ttl *time.Time) error {
 	}
 
 	return nil
-
 }
 
 func (t CRUD) Get(ids ...interface{}) (interface{}, error) {
-
 	rowKeys := t.RowKeys()
 	rangeKeys := t.RangeKeys()
 
 	if len(ids) < len(rowKeys)+len(rangeKeys) {
-		return nil, errors.New(fmt.Sprintf("To few key-values to query for row (%d of the required %d)", len(ids), len(rowKeys)+len(rangeKeys)))
+		return nil, fmt.Errorf("To few key-values to query for row (%d of the required %d)", len(ids), len(rowKeys)+len(rangeKeys))
 	}
 
 	where := []string{}
@@ -112,7 +108,6 @@ func (t CRUD) Get(ids ...interface{}) (interface{}, error) {
 	}
 
 	return row, nil
-
 }
 
 func (t CRUD) List(ids ...interface{}) (interface{}, error) {
@@ -120,7 +115,6 @@ func (t CRUD) List(ids ...interface{}) (interface{}, error) {
 }
 
 func (t CRUD) Update(row interface{}) error {
-
 	rowKeys := t.RowKeys()
 	rangeKeys := t.RangeKeys()
 
@@ -162,19 +156,18 @@ func (t CRUD) Update(row interface{}) error {
 	}
 
 	if len(ids) < len(rowKeys)+len(rangeKeys) {
-		return errors.New(fmt.Sprintf("To few key-values to update row (%d of the required minimum of %d)", len(ids), len(rowKeys)+len(rangeKeys)))
+		return fmt.Errorf("To few key-values to update row (%d of the required minimum of %d)", len(ids), len(rowKeys)+len(rangeKeys))
 	}
 
 	err := t.Query(fmt.Sprintf(`UPDATE %q.%q SET %s WHERE %s`, t.Keyspace().Name(), t.Name(), strings.Join(set, ", "), strings.Join(where, " AND ")), append(vals, ids...)...).Exec()
 	if err != nil {
 		return err
 	}
-	return nil
 
+	return nil
 }
 
 func (t CRUD) Delete(row interface{}) error {
-
 	rowKeys := t.RowKeys()
 	rangeKeys := t.RangeKeys()
 
@@ -199,7 +192,7 @@ func (t CRUD) Delete(row interface{}) error {
 	}
 
 	if len(ids) < len(rowKeys)+len(rangeKeys) {
-		return errors.New(fmt.Sprintf("To few key-values to delete row (%d of the required %d)", len(ids), len(rowKeys)+len(rangeKeys)))
+		return fmt.Errorf("To few key-values to delete row (%d of the required %d)", len(ids), len(rowKeys)+len(rangeKeys))
 	}
 
 	err := t.Query(fmt.Sprintf(`DELETE FROM %q.%q WHERE %s`, t.Keyspace().Name(), t.Name(), strings.Join(where, " AND ")), ids...).Exec()
@@ -207,7 +200,6 @@ func (t CRUD) Delete(row interface{}) error {
 		return err
 	}
 	return nil
-
 }
 
 func (t CRUD) Range(ids ...interface{}) RangeInterface {
@@ -361,5 +353,4 @@ func (r Range) Fetch() (interface{}, error) {
 	}
 
 	return result.Interface(), nil
-
 }

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -1,4 +1,4 @@
-// This package provides some punk-rock reflection which is not in the stdlib.
+// Package reflect provides some punk-rock reflection which is not in the stdlib.
 package reflect
 
 import (

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -75,36 +75,64 @@ func FieldsAndValues(val interface{}) ([]string, []interface{}, bool) {
 	return fields, values, true
 }
 
-var structMapMutex sync.RWMutex
-var structMap = make(map[r.Type]*structInfo)
+type typeMap struct {
+	m sync.RWMutex
 
-type fieldInfo struct {
-	Key string
-	Num int
+	types map[r.Type]*StructInfo
 }
 
-type structInfo struct {
+// Get returns information of a mapped struct if it has been processed by gocqltable.
+func (t *typeMap) Get(i interface{}) (*StructInfo, bool) {
+	var rt r.Type
+	switch v := i.(type) {
+	case r.Type:
+		rt = v
+	default:
+		rt = r.Indirect(r.ValueOf(i)).Type()
+	}
+	t.m.Lock()
+	s, found := t.types[rt]
+	t.m.Unlock()
+	return s, found
+}
+
+func (t *typeMap) set(rt r.Type, v *StructInfo) {
+	t.m.Lock()
+	t.types[rt] = v
+	t.m.Unlock()
+}
+
+// TypeMap holds all the type's structure information.
+var TypeMap = &typeMap{types: make(map[r.Type]*StructInfo)}
+
+// FieldInfo holds information about a struct field.
+type FieldInfo struct {
+	Key  string
+	Num  int
+	Type string
+}
+
+// StructInfo contains information about a struct's fields.
+type StructInfo struct {
 	// FieldsMap is used to access fields by their key
-	FieldsMap map[string]fieldInfo
+	FieldsMap map[string]*FieldInfo
 	// FieldsList allows iteration over the fields in their struct order.
-	FieldsList []fieldInfo
+	FieldsList []*FieldInfo
 }
 
-func getStructInfo(v r.Value) *structInfo {
+func getStructInfo(v r.Value) *StructInfo {
 	st := r.Indirect(v).Type()
-	structMapMutex.RLock()
-	sinfo, found := structMap[st]
-	structMapMutex.RUnlock()
+	sinfo, found := TypeMap.Get(st)
 	if found {
 		return sinfo
 	}
 
 	n := st.NumField()
-	fieldsMap := make(map[string]fieldInfo, n)
-	fieldsList := make([]fieldInfo, 0, n)
+	fieldsMap := make(map[string]*FieldInfo, n)
+	fieldsList := make([]*FieldInfo, 0, n)
 	for i := 0; i != n; i++ {
 		field := st.Field(i)
-		info := fieldInfo{Num: i}
+		info := &FieldInfo{Num: i}
 		tag := field.Tag.Get("cql")
 		// If there is no cql specific tag and there are no other tags
 		// set the cql tag to the whole field tag
@@ -122,15 +150,15 @@ func getStructInfo(v r.Value) *structInfo {
 			panic(msg)
 		}
 
+		typeTag := field.Tag.Get("cql_type")
+		if typeTag != "" {
+			info.Type = typeTag
+		}
+
 		fieldsList = append(fieldsList, info)
 		fieldsMap[info.Key] = info
 	}
-	sinfo = &structInfo{
-		fieldsMap,
-		fieldsList,
-	}
-	structMapMutex.Lock()
-	structMap[st] = sinfo
-	structMapMutex.Unlock()
+	sinfo = &StructInfo{fieldsMap, fieldsList}
+	TypeMap.set(st, sinfo)
 	return sinfo
 }

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -1,9 +1,9 @@
 package reflect
 
 import (
-	"github.com/gocql/gocql"
-
 	"testing"
+
+	"github.com/gocql/gocql"
 )
 
 type Tweet struct {

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -1,6 +1,7 @@
 package reflect
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gocql/gocql"
@@ -11,6 +12,18 @@ type Tweet struct {
 	ID            gocql.UUID  `cql:"id"`
 	Text          string      `teXt`
 	OriginalTweet *gocql.UUID `json:"origin"`
+	TestSet       []string    `cql:"test_set" cql_type:"set"`
+}
+
+func TestGetStructInfoForCQLType(t *testing.T) {
+	e := &Tweet{}
+	i := getStructInfo(reflect.ValueOf(e))
+	if i.FieldsMap["id"].Type != "" {
+		t.Error("Field id should have no type set")
+	}
+	if i.FieldsMap["test_set"].Type != "set" {
+		t.Error("Field test_set should have type set to 'set'")
+	}
 }
 
 func TestStructToMap(t *testing.T) {
@@ -20,7 +33,7 @@ func TestStructToMap(t *testing.T) {
 		t.Error("map is not nil when val is a string")
 	}
 	if ok {
-		t.Error("ok result from StructToMap when the val is a string")
+		t.Error("ok result from StructToMap when the value is a string")
 
 	}
 
@@ -29,6 +42,7 @@ func TestStructToMap(t *testing.T) {
 		gocql.TimeUUID(),
 		"hello gocassa",
 		nil,
+		[]string{"test"},
 	}
 
 	m, ok = StructToMap(tweet)
@@ -48,6 +62,10 @@ func TestStructToMap(t *testing.T) {
 	}
 	if m["OriginalTweet"] != tweet.OriginalTweet {
 		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
+	}
+	_, ok = m["test_set"].([]string)
+	if !ok {
+		t.Errorf("Expected %v but got %s", tweet.TestSet, m["test_set"])
 	}
 
 	id := gocql.TimeUUID()
@@ -135,13 +153,13 @@ func TestFieldsAndValues(t *testing.T) {
 	}{
 		{
 			Tweet{},
-			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
-			[]interface{}{"", emptyUUID, "", nilID},
+			[]string{"Timeline", "id", "teXt", "OriginalTweet", "test_set"},
+			[]interface{}{"", emptyUUID, "", nilID, []string{}},
 		},
 		{
-			Tweet{"timeline1", id, "hello gocassa", &id},
-			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
-			[]interface{}{"timeline1", id, "hello gocassa", &id},
+			Tweet{"timeline1", id, "hello gocassa", &id, []string{"test1", "test2"}},
+			[]string{"Timeline", "id", "teXt", "OriginalTweet", "test_set"},
+			[]interface{}{"timeline1", id, "hello gocassa", &id, []string{"test1", "test2"}},
 		},
 	}
 	for _, test := range tests {
@@ -171,9 +189,23 @@ func assertValuesEqual(t *testing.T, a, b []interface{}) {
 	}
 
 	for i := range a {
-		if a[i] != b[i] {
-			t.Errorf("expected values %v but got %v a[i] = %v and b[i] = %v", a, b, a[i], b[i])
-			return
+		switch reflect.ValueOf(a[i]).Kind() {
+		case reflect.Slice:
+			s1 := reflect.ValueOf(a[i])
+			s2 := reflect.ValueOf(b[i])
+			for j := 0; j < s1.Len(); j++ {
+				if s1.Index(j).Interface() != s2.Index(j).Interface() {
+					t.Errorf("expected values %v but got %v a[i][j] = %v and b[i][j] = %v",
+						a[i], b[i], s1.Index(j).Interface(), s2.Index(j).Interface(),
+					)
+					return
+				}
+			}
+		default:
+			if a[i] != b[i] {
+				t.Errorf("expected values %v but got %v a[i] = %v and b[i] = %v", a, b, a[i], b[i])
+				return
+			}
 		}
 	}
 }

--- a/table.go
+++ b/table.go
@@ -39,7 +39,6 @@ func (t Table) CreateWithProperties(props ...string) error {
 }
 
 func (t Table) create(props ...string) error {
-
 	if t.session == nil {
 		t.session = defaultSession
 	}

--- a/table.go
+++ b/table.go
@@ -58,10 +58,10 @@ func (t Table) create(props ...string) error {
 	if !ok {
 		panic("Unable to get map from struct during create table")
 	}
-
+	si, _ := r.TypeMap.Get(t.Row())
 	for key, value := range m {
 		key = strings.ToLower(key)
-		typ, err := stringTypeOf(value)
+		typ, err := stringTypeOf(value, si.FieldsMap[key])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
TL;DR: I needed a way to tell gocqltable to handle a slice in the model struct definition as a set in CQL and not as a list.

Not really happy with the amount of code needed to get this in here. Along the way, I fixed a few of `go vet`'s concerns regarding certain code constructs, safely exposed the struct information map to the outside world (now usable in your project using gocqltable) and added a way to query indexed map/list/set values (or keys) via CQL's `CONTAINS` clause. There's a few basic tests added in there as well so maybe there's parts of this you want to pull into upstream.

I'll be using Go 1.6's vendor feature to embed my fork in the current project (forks were a real pain before – maybe we should do this for the dependencies of gocqltable as well?) so I'm not in a rush to get this merged.

Thanks for the library!
