### PR TITLE
Generalize handling WHERE IN clauses

### DIFF
--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"strings"
-	"reflect"
 	"time"
 
 	"github.com/kristoiv/gocqltable"


### PR DESCRIPTION
This cleans up the changes I made in #3. It pushes clauses for `WHERE col IN (?)` statements into the where clause handler, thereby drops the string value constraint and then lets gocql fill in the values correctly interpolated and escaped.

If you want I can get started on a few basic tests – however, I've been using `WHERE IN` extensively in our codebase and the changes are sufficiently easy to understand.